### PR TITLE
support more foodcritic version, ignore warning

### DIFF
--- a/op-foodcritic-rules.gemspec
+++ b/op-foodcritic-rules.gemspec
@@ -5,7 +5,7 @@ $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 
 Gem::Specification.new do |spec|
   spec.name          = 'op-foodcritic-rules'
-  spec.version       = '0.0.1'
+  spec.version       = '0.0.2'
   spec.authors       = ['Ofir Petrushka']
   spec.email         = ['ofir.petrushka@gmail.com']
   spec.description   = 'Recommendation foodcritic rules.'
@@ -19,7 +19,7 @@ Gem::Specification.new do |spec|
   spec.require_paths = ['lib']
   spec.required_ruby_version = '>= 1.9.2'
 
-  spec.add_dependency 'foodcritic', '~> 7'
+  spec.add_dependency 'foodcritic'
 
   spec.add_development_dependency 'bundler', '~> 1'
   spec.add_development_dependency 'rake', '~> 11'


### PR DESCRIPTION
Remove foodcritic version pinning.

At least foodcritic ~6, ~7 work, the gem builder don't like unbound versions and don't think I can do multiple versions at this point in time. 
